### PR TITLE
200712

### DIFF
--- a/7월/200712.md
+++ b/7월/200712.md
@@ -1,0 +1,258 @@
+1. 자식 클래스에서 부모 클래스의 메서드를 오버라이딩하는 방법이 자주 쓰이는 이유는?
+
+2. 밑에서, 2번째 줄에 out.Inner inner = out.new Inner();가 안되는 이유?
+
+Outer out = new Outer();
+Outer.Inner inner = out.new Inner();
+
+곧, Outer out = new Outer(); Outer.Inner inner = out.new Inner(); 와 Outer.Inner inner = new Outer.Inner();의 차이점
+
+3. 이클립스에서 자바 프로젝트 생성시 module-info.java 클래스가 자동으로 생성되는데 이 친구가 있을 때 내가 따로 클래스를 만들어주면 경로에 해당하는 파일이 빨간줄이 뜨면서 오류가 뜸. 앞서 언급한 클래스를 지우면 정상 실행.
+
+
+### 41강
+
+1. Final
+	- Final은 더 이상 변경할 수 없다는 의미를 가지고 있는 키워드이다.
+	- 변수 : 변수에 값을 넣을 수 없으며 변수의 선언과 동시에 초기화를 반드시 해줘야 한다.
+	- 메서드 : 상속관계에 있을 때 자식 클래스에서 메서드를 Overriding 할 수 없다. 
+	- 클래스 : 상속을 하지 못하도록 막아 줄 수 있다.
+
+```Java
+public class FinalTest {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		Class1 c1 = new Class1();
+		//c1.a = 300; // Final 변수 -> 할당할 수 없으므로 오류!
+		System.out.println(c1.a); // 값을 사용하는데에는 이상 없음
+	}
+
+}
+
+class Class1 extends Class2{
+	final int a = 100;// 선언과 동시에 값을 넣어주어야 함
+	
+	public void method1() {
+		// a = 200; // Final 변수 -> 할당할 수 없으므로 오류!
+	}
+	
+	/*
+	public void method2() {// 메서드 앞에 final 붙어 있으면  이 메서드가 들어있는 부모 클래스를 상속받은 자식 클래스에서 이 메서드를  오버라이딩 할 수 없다.
+		System.out.println("overriding method");
+	}
+	*/
+}
+
+class Class2{
+	
+	public final void method2() {
+		System.out.println("final method");
+	}
+	
+}
+
+final class Class3{
+
+}
+
+/*
+class Class4 extends Class3{// 클래스 앞에 final 붙어 있으면 이 메서드가 이 메서드는 상속받을 수 없다.
+
+}
+*/
+```
+
+1. 학 습 정 리
+	- final은 더 이상 변경할 수 없다라는 의미를 가지고 있으며 클래스, 메서드, 변수와 함께 사용할 수 있다. 
+
+### 42강
+
+1. 중첩 클래스
+	- 클래스 내부에 클래스를 만들어서 사용하는 걸 의미한다.
+	- 프로그래밍을 할 때 여러 군데서 사용하는 클래스가 아니라면 파일을 새로 만들거나 코드의 아래 부분으로 내려서 만들지 않고 바로 만들어서 바로 쓸 수 있도록 하는 개념이다.
+	- 경우에 따라서는 객체를 생성할 수 있는 부분이 클래스를 설계한 부분으로 한정되어 있는 경우도 있다.
+	- 클래스 내부에 만든 클래스를 Inner CLass라고 부르며 Inner 클래스를 감싸고 있는 클래스 있는 클래스를 Outer Class라고 부른다.
+
+1. 일반 중첩 클래스
+	- 클래스 내부에 클래스를 만들어서 사용하는 경우이다.
+	- Inner 클래스의 객체를 만들기 위해서는 반드시 Outer 클래스의 객체를 생성하고 이를 통해 Inner 클래스를 만들어야 한다. 
+	- Inner 클래스는 Outer 클래스의 멤버에 접근할 수 있지만 Outer 클래스는 Inner 클래스의 멤버에 접근할 수 없다. Inner 클래스의 멤버는 Outer 클래스의 객체가 생성되어 있다는 가정하에 사용하므로 접근이 가능하지만 Outer 클래스는 Inner 클래스의 객체의 생성과 관계가 없으므로 Inner 클래스에 대한 접근이 자유롭지 못하다.
+
+1. static 중첩 클래스
+	- 일반 중첩 클래스에서 Inner 클래스가 static 으로 정의된 경우이다.
+	- Inner 클래스가 Static 으로 정의되어 있어 Outer 클래스의 객체 생성 없이 바로 객체 생성이 가능하다.
+	- Inner 클래스에서는 Outer 클래스에 정의된 멤버 중에 Static 멤버만 접근이 가능하다. "Outer 클래스의 객체 생성없이 바로 Inner 클래스의 객체를 생성하므로 Outer 클래스의 객체가 생성되지 않았다고 가정하여 개발"을 해야 한다. 
+
+```Java
+public class ReiterrationClass2 {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		//Outer out = new Outer();
+		//Outer.Inner inner = out.new Inner();
+
+		//out.outerMethod(); // static 아닐 경우
+		//inner.innerMethod();
+		
+		Outer.Inner inner = new Outer.Inner();// 아우터 객체 생성없이 바로 객체 생성 가능
+		inner.innerMethod();
+		
+		//Outer.Inner.innerMethod(); // 클래스가 static이 된다고 해서 멤버들이 모두 static이 되는 것은 아니다.
+		
+	}
+
+}
+
+class Outer{
+	int outer1 = 10;
+	static int outer2 = 20;
+	
+	void outerMethod() {
+		System.out.println("Outer의 메서드입니다.");
+		// System.out.println("inner1); // 아우터 클래스에서는 이너 클래스의 멤버에 접근할 수 없다. 
+	}
+	
+	static class Inner{
+		int inner1 = 20;
+		
+		void innerMethod() {
+			System.out.println("Inner의 메서드입니다.");
+			// System.out.println(outer1);// static이 아닐 경우 아우터 클래스의 멤버에 접근가능, static이므로 static 멤버에만 접근 가능
+			System.out.println(outer2);
+		}
+	}
+}
+```
+
+1. 메서드 내부의 중첩 클래스
+	- 클래스를 메서드 내부에 만들 경우를 의미한다.
+	- 메서드 내부에 만든 중첩 클래스는 다른 곳에서 참조 변수 조차 선언할 수 없다.
+	- Inner 클래스에서는 클래스 내부에 선언한 변수만 사용할 수 있으며 클래스를 만든 메서드 내부에 있는 지역 변수 중 final 변수만 접근이 가능하다. 그 외의 모든 변수는 접근이 불가능하다.
+
+```Java
+public class ReiterationClass3 {
+	
+	// Inner in;// 참조 변수 조차도 선언할 수 없다.
+	int a = 10;
+	final int fa = 100;
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// int b = 20;
+		final int fb = 200;
+		class Inner{
+			
+			void innerMethod() {
+				// System.out.println(a);// static 멤버가 아니기 때문에 접근할 수 없음 + 바깥쪽 클래스의 멤버이기 때문에 접근할 수 없음
+				// System.out.println(b);// final 변수가 아니기 때문에 접근할 수 없음
+				System.out.println(fb);// 메서드 내부의 final 변수는 접근 가능
+				System.out.println(fa);// final 일지라도 바깥쪽 클래스의 멤버에는 접근 x
+			}
+		}
+		Inner inner = new Inner();
+		inner.innerMethod();
+	}
+
+}
+```
+
+1. 익명 중첩 클래스
+	- 클래스로 부터 객체 생성을 할 때 클래스 내부 코드를 바로 작성하는 것을 의미한다.
+	- 원본 클래스가 가지고 있는 메서드를 Overriding 해야 할 경우 상속받은 클래스를 만들지 않고 바로 Overriding 을 할 수 있다.
+	- 추상 클래스라는 것을 이용할 때 자주 사용하는 기법이다.
+
+```Java
+public class ReiterationClass3 {
+	
+	public static void main(String[] args) {
+		Class200 c1 = new Class200();
+		c1.disp();
+		
+		Class200 c2 = new Class200() {// 객체 생성과 동시에 클래스200의 메서드를 오버라이딩하는 경우
+			public void disp() {
+				System.out.println("익명 중첩 클래스의 메서드");
+				super.disp();
+			}
+		};
+		c2.disp();// c2라는 참조 변수를 이용해야지만 사용할 수 있다. 일회성이다. 
+	}
+
+}
+
+class Class200{
+	public void disp() {
+		System.out.println("원본 클래스의 disp 메서드");
+	}
+}
+```
+
+1. 학 습 정 리
+	- 중첩 클래스는 클래스 내부에 클래스를 만드는 것을 의미한다.
+	- 중첩 클래스는 일반 중첩 클래스, static 중첩 클래스, 메서드 내의 중첩 클래스, 익명 중첩 클래스로 구분된다.
+	- 중첩 클래스는 클래스를 만들 때 파일을 따로 만들거나 다른 쪽으로 이동해서 클래스를 만들고 다시 돌아와야 하는 불편함을 덜어 주기 위해서 제공된다. 
+
+### 43강
+
+1. 추상 메서드
+	- 클래스를 작성할 때 메서드를 구현하지 않고 선언만 해 놓은 메서드를 추상 메서드라고 부른다.
+	- 추상 메서드는 구현 되지 않은 메서드 이므로 메서드를  구현 해야지만 사용이 가능하다.
+	- 추상 메서드는 접근 제한자와 리턴 타입 중간에 abstract 라는 키워드를 붙혀준다.
+	- 구현된 메서드 : public void method(){}
+	- 구현 되지 않은 메서드 : pubnlic abstract void method();
+
+1. 추상 클래스
+	- 추상 메서드를 하나라도 가진 클래스를 추상 클래스라고 부른다.
+	- 추상 클래스는 구현되지 않은 메서드인 추상 메서드를 가지고 있기 때문에 직접 객체를 생성할 수 없다.
+	- 추상 클래스의 기능을 사용하기 위해서는 반드시 추상 클래스를 상속받는 서브 클래스가 있어야 한다.
+	- 추상 클래스를 상속받은 서브 클래스는 추상 메서드를 반드시 구현해야 한다.
+	- 추상 클래스는 접근 제한자와 class 키워드 사이에 abstract를 붙혀 준다.
+	- 추상 클래스를 사용하면 특정 메서드의 구현에 대한 강제성을 줄 수 있다.
+	- public abstract class ClassName{}
+
+```Java
+public class AbstractTest {
+
+	public static void main(String[] args) {
+		// TODO Auto-generated method stub
+		// Animal a = new Animal();
+		Human h = new Human();
+		h.sayHi();
+		
+		Animal a = new Human();// 다형성 이용
+		a.sayHi();
+		
+		Animal a2 = new Animal() {// 익명 중첩 클래스 이용 바로 사용!!
+
+			@Override
+			public void sayHi() {
+				// TODO Auto-generated method stub
+				System.out.println("반갑습니다");
+			}
+		};
+
+		a2.sayHi();
+	}
+
+}
+
+abstract class Animal{// abstract 반드시 붙여야 함
+	public abstract void sayHi();
+}
+
+class Human extends Animal{
+
+	@Override
+	public void sayHi() {
+		// TODO Auto-generated method stub
+		System.out.println("안녕하세요");
+	}
+	
+}
+```
+
+1. 학 습 정 리 
+	- 클래스 내에 구현하지 않은 메서드를 추상 메서드 라고 부른다.
+	- 추상 메서드를 가지고 있는 클래스를 추상 클래스라고 부른다.
+	- 추상 클래스는 서브 클래스를 통해 사용할 수 있다.
+	- 추상 클래스를 이용하면 메서드 구현에 대한 강제성을 부여할 수 있다.


### PR DESCRIPTION
1. 자식 클래스에서 부모 클래스의 메서드를 오버라이딩하는 방법이 자주 쓰이는 이유는?

2. 밑에서, 2번째 줄에 out.Inner inner = out.new Inner();가 안되는 이유?

Outer out = new Outer();
Outer.Inner inner = out.new Inner();

곧, Outer out = new Outer(); Outer.Inner inner = out.new Inner(); 와 Outer.Inner inner = new Outer.Inner();의 차이점

3. 이클립스에서 자바 프로젝트 생성시 module-info.java 클래스가 자동으로 생성되는데 이 친구가 있을 때 내가 따로 클래스를 만들어주면 경로에 해당하는 파일이 빨간줄이 뜨면서 오류가 뜸. 앞서 언급한 클래스를 지우면 정상 실행.

-> 45강까지 들을 예정이었으나, 43강까지 밖에 수강하지 못하였습니다. 화요일까지 48강까지 끝내고 문제 풀어보겠습니다.